### PR TITLE
Catch also translation strings with parameters

### DIFF
--- a/src/Command/TranslationHelperCommand.php
+++ b/src/Command/TranslationHelperCommand.php
@@ -102,7 +102,7 @@ class TranslationHelperCommand extends Command
     {
         $matches = [];
 
-        preg_match_all("#{$functionName}\(\'(.*?)\'\)#", $content, $matches);
+        preg_match_all("#{$functionName}\(\s*\'(.*?)\'\s*[\)\,]#", $content, $matches);
 
         if (! empty($matches)) {
             foreach ($matches[1] as $match) {


### PR DESCRIPTION
* Catch also translation strings with parameters
* Fix: catch also white spaces or line breaks outside the translation string

I changed the regex to catch translation string with parameters like this: `__('Hello :user_name', ['user_name' => $user->name])` and even this weird one:
```
__(
    'Hello :user_name'
    , // I deliberately put this comma here
    ['user_name' => $user->name]
)
```